### PR TITLE
Add social metadata.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,13 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@javers_org" />
+<meta property="og:url" content="https://javers.org/" />
+<meta property="og:title" content="{{ page.title }}{{ titleSuffix }}" />
+<meta property="og:description" content="{{ page.description }}" />
+<meta property="og:image" content="https://javers.org/img/javers-og-image.png" />
+
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 


### PR DESCRIPTION
Added [OpenGraph](http://ogp.me/) and [Twitter](https://dev.twitter.com/cards/types/summary) metadata to generate cards in social media. Below is an example render of twitter card with link to javers.org

![twitter card](https://user-images.githubusercontent.com/1616386/27518014-7ca56d0c-59d6-11e7-8979-33000c613b0e.png)
