### PR TITLE
Add 6.10.0 release notes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ github_core_main_url: https://github.com/javers/javers/blob/master/javers-core/s
 github_spring_main_url: https://github.com/javers/javers/blob/master/javers-spring/src/main/java/
 github_core_test_url: https://github.com/javers/javers/blob/master/javers-core/src/test/groovy/
 github_core_test_java_url: https://github.com/javers/javers/blob/master/javers-core/src/test/java/
-javers_current_version: "6.9.1"
+javers_current_version: "6.10.0"
 
 url: "https://javers.org"
 

--- a/documentation/spring-boot-integration/index.md
+++ b/documentation/spring-boot-integration/index.md
@@ -159,6 +159,9 @@ javers:
   documentDbCompatibilityEnabled: false
   objectAccessHook: org.javers.spring.mongodb.DBRefUnproxyObjectAccessHook
   snapshotsCacheSize: 5000
+  snapshotCollectionName: "jv_snapshots"
+  headCollectionName: "jv_head_id"
+  schemaManagementEnabled: true
 ```
 
 #### Transaction management in the MongoDB starter

--- a/release-notes.md
+++ b/release-notes.md
@@ -28,7 +28,37 @@ Javers core and Javers persistence modules require Java 11:
 * `javers-persistence-mongo`
 * `javers-persistence-sql`:
 
-  Javers v. 6.9.1 is the last version compatible with Java 8 and Spring Boot 2.7.7.
+  Javers v. 6.10.0 is the last version compatible with Java 8 and Spring Boot 2.7.7.
+
+### 6.10.0
+released on 2023-02-15
+* [1254](https://github.com/javers/javers/issues/1260)
+  Added possibility to disable the schema management in Mongo Repository via application code.
+
+  Usage:
+  ```Java
+        MongoRepository mongoRepository = new MongoRepository(getMongoDb(),
+                mongoRepositoryConfiguration()
+                        .withSnapshotCollectionName("jv_custom_snapshots_")
+                        .withHeadCollectionName("jv_custom_head_id_")
+                        .withSchemaManagementEnabled(false)
+                        .build())
+  
+    ```
+
+  See also [MongoE2EWithSchemaEnabledTest.groovy](https://github.com/javers/javers/blob/master/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/MongoE2EWithSchemaEnabledTest.groovy)
+
+* Made Mongo repository configuration parameters(_snapshotCollectionName, headCollectionName, schemaManagementEnabled_) configurable through Spring boot configuration files (`application.yml`)
+
+Usage:
+
+  ```yaml
+    javers:
+      snapshotCollectionName: "jv_custom_snapshots"
+      headCollectionName: "jv_custom_head_id"
+      schemaManagementEnabled: false
+  ```
+
 
 ### 6.9.1
 released on 2023-02-01


### PR DESCRIPTION
With release of 6.10.0, new feature's release notes added.

[Release-6.10.0](https://repo1.maven.org/maven2/org/javers/javers-core/6.10.0/) existed, but not visible searching in [central-repo ](https://search.maven.org/artifact/org.javers/javers-spring-mongo) 