### PR TITLE
Clarify transaction management when using a dedicated mongodb database for javers and fix a header format

### DIFF
--- a/documentation/spring-boot-integration/index.md
+++ b/documentation/spring-boot-integration/index.md
@@ -219,6 +219,8 @@ javers:
 
 If the `javers.mongodb` property is defined, either `host` or `uri` has to be set.
   
+If you use a transactional Javers instance (see [Transaction management in the MongoDB starter](#transaction-management-in-the-mongodb-starter)) the audit operations issued in the dedicated MongoDB database for Javers won't participate in the application's data transactions.
+
 #### MongoClientSettings
 If you need more control over Javers’ dedicated `MongoClient`,
 you can configure a `MongoClientSettings` bean named `javersMongoClientSettings`.
@@ -714,7 +716,7 @@ public class JaVersConfiguration {
 }
 ```
 
-<h3 id="javers-faq-db">Database related customization</h2>
+<h3 id="javers-faq-db">Database related customization</h3>
 Q. Java `Instant` precision is `9` while `PostgreSQL` timestamp precision is `6` (rounded). 
 As the result, JaVers reports `created` Instant as updated for an update after an insert (which JaVers records with nanos).
 


### PR DESCRIPTION
Closes #127 


this fix:
<img width="799" height="39" alt="image" src="https://github.com/user-attachments/assets/e8a643b5-d41a-49fc-9a1f-a3b1d495d21d" />

is fixing this problem in the visualization of:  https://javers.org/documentation/spring-boot-integration/
<img width="1199" height="1452" alt="image" src="https://github.com/user-attachments/assets/af7f5825-3881-48a0-a4df-84bf1ae1aefa" />

