### PR TITLE
docs: fix 7 typos in documentation

### DIFF
--- a/documentation/diff-configuration/index.md
+++ b/documentation/diff-configuration/index.md
@@ -7,8 +7,8 @@ sidebar-url: docs-sidebar.html
 ---
 
 Javers’ diff algorithm has a pluggable construction.
-Each Java type is mapped to exact one [Javers type](/documentation/domain-configuration/#javers-types).
-Each Javers type is mapped to exact one *comparator*.
+Each Java type is mapped to exactly one [Javers type](/documentation/domain-configuration/#javers-types).
+Each Javers type is mapped to exactly one *comparator*.
 
 In most cases, you will rely on Javers’ core comparators.
 Optionally, you can register [Custom comparators](#custom-comparators)
@@ -20,13 +20,13 @@ For [comparing Lists](#list-algorithms), JaVers has three core comparators:
 <h2 id="list-algorithms">List comparing algorithms</h2>
 Generally, we recommend using **Levenshtein**, because it’s the smartest one.
 But use it with caution, it could be slow for long lists,
-say more then 300 elements.
+say more than 300 elements.
 
 The main advantage of **Simple** algorithm is speed, it has linear computation complexity.
 The main disadvantage is the verbose output.
 
 Choose the **Set** algorithm if you don’t care about the items ordering. 
-JaVers will convert all Lists to Sets before comparision.
+JaVers will convert all Lists to Sets before comparison.
 This algorithm produces the most concise output (only `ValueAdded` and `ValueRemoved`).   
 
 You can switch to Levenshtein or Set in JaversBuilder:
@@ -89,7 +89,7 @@ javers.compare(['a','b','c','d'],
                ['a','g','e','i'])
 ```
 
-the change list will the same:
+the change list will be the same:
 
 <table class="table" width="100%" style='word-wrap: break-word; font-family: monospace;'>
     <tr>

--- a/documentation/getting-started/index.md
+++ b/documentation/getting-started/index.md
@@ -55,7 +55,7 @@ and [Javers’ Spring integration](/documentation/spring-integration/).
 
 - [[Baeldung] Intro to JaVers](https://www.baeldung.com/javers)
   <br/>
-    **Teaser**: This article, written by Eugen Baeldung, serves as a starting point for understanding JaVers.
+    **Teaser**: This article, published on Baeldung, serves as a starting point for understanding JaVers.
    It provides an overview of JaVers’ core feature &mdash;  **the Object Diff**. It covers comparing objects,
    collections, and object graphs.
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -41,4 +41,4 @@ This is the niche that JaVers fills. In JaVers, *version* and *change* are **fir
  
 <h2 id="licence">Licence</h2>
 JaVers is available under open source
-[Apache License, Version 2.0](http://opensource.org/licenses/Apache-2.0").
+[Apache License, Version 2.0](http://opensource.org/licenses/Apache-2.0).


### PR DESCRIPTION
## Summary

Fix 7 issues across 3 files:

- `documentation/diff-configuration/index.md`: "exact one" → "exactly one" (2 occurrences)
- `documentation/diff-configuration/index.md`: "more then" → "more than"
- `documentation/diff-configuration/index.md`: "comparision" → "comparison"
- `documentation/diff-configuration/index.md`: "will the same" → "will be the same"
- `documentation/getting-started/index.md`: "Eugen Baeldung" → "published on Baeldung" (Baeldung is the site name, not the author's surname)
- `documentation/index.md`: Remove stray quote from Apache License URL that broke the markdown link

No functional changes — documentation only.

## Dropped findings

- `_includes/navbar.html`: "comparision" in URL path `/blog/2017/12/javers-vs-envers-comparision.html` — the typo is baked into the blog post filename (`2017-12-29-javers-vs-envers-comparision.md`), so changing the navbar href without renaming the file would break the link. Renaming the file would break external links. Skipped.